### PR TITLE
Updating to NOT use ElasticSearch apart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
-# fess
+# FESS docker-compose
 FESS Docker Container. See more at https://github.com/codelibs/fess
+
 Demo at https://search.n2sm.co.jp
 
 # Before bringing the Container up
@@ -18,17 +19,8 @@ services:
     image: codelibs/fess:12.1
     ports:
       - "8080:8080"
-    environment:
-      - ES_HTTP_URL=http://elasticsearch:9200
-      - ES_TRANSPORT_URL=elasticsearch:9300
-      - FESS_DICTIONARY_PATH=/var/lib/elasticsearch/config/
-
-  elasticsearch:
-    image: elasticsearch:5.6
-    ports:
-      - "9200:9200"
     volumes:
-      - elasticsearch:/usr/share/elasticsearch/data
+      - elasticsearch:/var/lib/elasticsearch
 
 volumes:
   elasticsearch:


### PR DESCRIPTION
As the FESS application still doesn't support correctly the ES_* env vars, remove this option